### PR TITLE
config: Fix CLI parsing of config files as flag options.

### DIFF
--- a/internal/cmd/agent/run.go
+++ b/internal/cmd/agent/run.go
@@ -27,7 +27,7 @@ func runCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			defaultCfg.Merge(fileCfg)
+			defaultCfg = defaultCfg.Merge(fileCfg)
 
 			// Merge in any configuration provided via command line flags which
 			// will override any previous configuration settings.

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -107,7 +107,7 @@ func AgentConfigFromCommand(cmd *cli.Command) *AgentConfig {
 func AgentConfigFromFiles(cmd *cli.Command) (*AgentConfig, error) {
 	var cfg *AgentConfig
 
-	for _, file := range cmd.StringArgs("config") {
+	for _, file := range cmd.StringSlice("config") {
 		fileCfg, err := parseAgentConfgigFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse config file %q: %w", file, err)

--- a/internal/config/agent_test.go
+++ b/internal/config/agent_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"slices"
 	"testing"
@@ -348,6 +349,190 @@ func Test_AgentConfigFromCommand(t *testing.T) {
 			cmdApp := &cli.Command{Flags: AgentConfigCommandFlags()}
 			tc.setFlags(cmdApp)
 			must.Eq(t, tc.expected, AgentConfigFromCommand(cmdApp))
+		})
+	}
+}
+
+func Test_AgentConfigFromFiles(t *testing.T) {
+	testCases := []struct {
+		name  string
+		files []struct {
+			content string
+			ext     string
+		}
+		expected    *AgentConfig
+		expectError bool
+	}{
+		{
+			name:        "no config files",
+			files:       nil,
+			expected:    nil,
+			expectError: false,
+		},
+		{
+			name: "single HCL file",
+			files: []struct {
+				content string
+				ext     string
+			}{
+				{
+					content: `
+server {
+  enabled = true
+}`,
+					ext: "hcl",
+				},
+			},
+			expected: &AgentConfig{
+				Server: &ServerConfig{
+					Enabled: helper.PointerOf(true),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "single JSON file",
+			files: []struct {
+				content string
+				ext     string
+			}{
+				{
+					content: `
+{
+  "server": {
+    "enabled": true
+  }
+}`,
+					ext: "json",
+				},
+			},
+			expected: &AgentConfig{
+				Server: &ServerConfig{
+					Enabled: helper.PointerOf(true),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple files merged with later overriding earlier",
+			files: []struct {
+				content string
+				ext     string
+			}{
+				{
+					content: `
+log {
+  level = "info"
+  json  = false
+}
+
+server {
+  enabled = true
+}`,
+					ext: "hcl",
+				},
+				{
+					content: `
+{
+  "log": {
+    "level": "debug"
+  }
+}`,
+					ext: "json",
+				},
+			},
+			expected: &AgentConfig{
+				Log: &LogConfig{
+					Level: "debug",
+					JSON:  helper.PointerOf(false),
+				},
+				Server: &ServerConfig{
+					Enabled: helper.PointerOf(true),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "non-existent file returns error",
+			files: []struct {
+				content string
+				ext     string
+			}{
+				{
+					content: "",
+					ext:     "nonexistent",
+				},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "invalid HCL content returns error",
+			files: []struct {
+				content string
+				ext     string
+			}{
+				{
+					content: `
+client {
+  disable_ipmasq = "not-a-bool"
+}`,
+					ext: "hcl",
+				},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "invalid JSON content returns error",
+			files: []struct {
+				content string
+				ext     string
+			}{
+				{
+					content: `{
+  "client": {
+    "disable_ipmasq": "not-a-bool"
+  }
+}`,
+					ext: "json",
+				},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmdApp := &cli.Command{Flags: AgentConfigCommandFlags()}
+
+			for i, f := range tc.files {
+				if f.content == "" && f.ext == "nonexistent" {
+					must.NoError(t, cmdApp.Set("config", "/tmp/does-not-exist-smuggle-test.hcl"))
+					continue
+				}
+
+				tmpFile, err := os.CreateTemp(t.TempDir(), fmt.Sprintf("config-%d-*.%s", i, f.ext))
+				must.NoError(t, err)
+				t.Cleanup(func() { _ = os.Remove(tmpFile.Name()) })
+
+				_, err = tmpFile.WriteString(f.content)
+				must.NoError(t, err)
+				must.NoError(t, tmpFile.Close())
+
+				must.NoError(t, cmdApp.Set("config", tmpFile.Name()))
+			}
+
+			result, err := AgentConfigFromFiles(cmdApp)
+
+			if tc.expectError {
+				must.Error(t, err)
+				must.Nil(t, result)
+			} else {
+				must.NoError(t, err)
+				must.Eq(t, tc.expected, result)
+			}
 		})
 	}
 }

--- a/internal/config/nomad.go
+++ b/internal/config/nomad.go
@@ -19,14 +19,14 @@ const (
 )
 
 type NomadConfig struct {
-	Address       string `hcl:"address" json:"address"`
-	Token         string `hcl:"token" json:"token"`
-	CACert        string `hcl:"ca_cert" json:"ca_cert"`
-	CAPath        string `hcl:"ca_path" json:"ca_path"`
-	ClientCert    string `hcl:"client_cert" json:"client_cert"`
-	ClientKey     string `hcl:"client_key" json:"client_key"`
-	TLSServerName string `hcl:"tls_server_name" json:"tls_server_name"`
-	SkipVerify    *bool  `hcl:"skip_verify" json:"skip_verify"`
+	Address       string `hcl:"address,optional" json:"address"`
+	Token         string `hcl:"token,optional" json:"token"`
+	CACert        string `hcl:"ca_cert,optional" json:"ca_cert"`
+	CAPath        string `hcl:"ca_path,optional" json:"ca_path"`
+	ClientCert    string `hcl:"client_cert,optional" json:"client_cert"`
+	ClientKey     string `hcl:"client_key,optional" json:"client_key"`
+	TLSServerName string `hcl:"tls_server_name,optional" json:"tls_server_name"`
+	SkipVerify    *bool  `hcl:"skip_verify,optional" json:"skip_verify"`
 }
 
 func DefaultNomadConfig() *NomadConfig {


### PR DESCRIPTION
The CLI config file parsing used an incorrect function to get the list of supplied files which meant no files were ever parsed. This change fixes that along with adding the optional parameter to Nomad config options, so they do not all need to be set and users can provided partials.