### PR TITLE
client: Fix subnet heartbeat not updating expiration.

### DIFF
--- a/internal/agent/client/heartbeat.go
+++ b/internal/agent/client/heartbeat.go
@@ -38,7 +38,7 @@ func (c *Client) startSubnetHeartbeat(cfg *types.Subnet) {
 			cfgCopy := cfg.Copy()
 			cfgCopy.Expiration = time.Now().Add(types.DefaultSubnetTTL)
 
-			_, err := c.store.SetSubnet(&types.StoreSetSubnetReq{Subnet: cfg})
+			_, err := c.store.SetSubnet(&types.StoreSetSubnetReq{Subnet: cfgCopy})
 
 			// Adjust the ticker interval based on success or failure. On
 			// success, we maintain the regular interval. On failure, we shorten
@@ -53,7 +53,7 @@ func (c *Client) startSubnetHeartbeat(cfg *types.Subnet) {
 
 				c.logger.Debug("updated subnet expiration",
 					zap.String("network", cfg.NetworkName),
-					zap.Time("new_expiration", cfg.Expiration),
+					zap.Time("expiration", cfgCopy.Expiration),
 				)
 			default:
 				ticker.Reset(10 * time.Second)


### PR DESCRIPTION
The client heartbeater was not updating its expiration deadline in the store. This was caused because the copied and modified object was not used when performing the store write; a stale object was instead written.

This change correctly uses the modified object, so that the expiration is updated.