### PR TITLE
vxlan: Fix asymmetric routing on multi-homed hosts.

### DIFF
--- a/internal/agent/client/subnet.go
+++ b/internal/agent/client/subnet.go
@@ -63,7 +63,10 @@ func (c *Client) handleSubnetDelete(subnets []*types.Subnet) {
 
 		c.logger.Debug("deleting remote subnet networking", subnet.LoggingPairs()...)
 
-		_, err := c.networkManager.DeleteRemote(&types.NetworkProviderDeleteRemoteReq{Subnet: subnet})
+		_, err := c.networkManager.DeleteRemote(&types.NetworkProviderDeleteRemoteReq{
+			Subnet:       subnet,
+			LocalSubnets: c.subnets,
+		})
 		if err != nil {
 			c.logger.Error("failed to delete remote subnet networking",
 				append(subnet.LoggingPairs(), zap.Error(err))...,
@@ -86,7 +89,10 @@ func (c *Client) handleSubnetSet(subnets []*types.Subnet) {
 
 		c.logger.Debug("setting up remote subnet networking", subnet.LoggingPairs()...)
 
-		_, err := c.networkManager.SetRemote(&types.NetworkProviderSetRemoteReq{Subnet: subnet})
+		_, err := c.networkManager.SetRemote(&types.NetworkProviderSetRemoteReq{
+			Subnet:       subnet,
+			LocalSubnets: c.subnets,
+		})
 		if err != nil {
 			c.logger.Error("failed to set up remote subnet networking",
 				append(subnet.LoggingPairs(), zap.Error(err))...,

--- a/internal/network/provider/vxlan/vxlan_ipv4_linux.go
+++ b/internal/network/provider/vxlan/vxlan_ipv4_linux.go
@@ -13,6 +13,7 @@ func (p *Provider) createIPv4(
 	cfg *types.Subnet,
 	providerCfg *Config,
 	vtepDevIndex int,
+	hostIfaceName string,
 ) (*netlink.Vxlan, error) {
 
 	intfName := cfg.InterfaceName()
@@ -44,15 +45,27 @@ func (p *Provider) createIPv4(
 		return nil, fmt.Errorf("failed to enable ipv4 forwarding: %w", err)
 	}
 
-	// Disable reverse path filtering for the VXLAN interface to allow asymmetric routing
-	// This is necessary for overlay networks where return traffic may come via different paths
+	// Disable reverse path filtering for the VXLAN interface to allow
+	// asymmetric routing. This is necessary for overlay networks where return
+	// traffic may come via different paths.
 	if _, err := sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/rp_filter", intfName), "0"); err != nil {
 		return nil, fmt.Errorf("failed to disable rp_filter for %s: %w", intfName, err)
 	}
 
-	// Also disable rp_filter on all interfaces to ensure forwarding works
+	// Disable rp_filter on the physical host interface explicitly. The kernel
+	// computes the effective rp_filter per interface, so setting conf/all=0
+	// alone is insufficient if the interface has its own non-zero value.
+	// Without this, asymmetric routing causes the host to silently drop return
+	// packets whose reverse path resolves to the VXLAN interface rather than
+	// the physical one.
+	if _, err := sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/rp_filter", hostIfaceName), "0"); err != nil {
+		return nil, fmt.Errorf("failed to disable rp_filter for host interface %s: %w", hostIfaceName, err)
+	}
+
+	// Set the global baseline to 0. This does not override per-interface values
+	// but ensures any newly created interfaces inherit a permissive default.
 	if _, err := sysctl.Sysctl("net/ipv4/conf/all/rp_filter", "0"); err != nil {
-		return nil, fmt.Errorf("failed to disable rp_filter for all interfaces: %w", err)
+		return nil, fmt.Errorf("failed to disable rp_filter globally: %w", err)
 	}
 
 	return vxlanLink, nil

--- a/internal/network/provider/vxlan/vxlan_linux.go
+++ b/internal/network/provider/vxlan/vxlan_linux.go
@@ -28,6 +28,17 @@ const (
 	// encapsulation. This is used to adjust the MTU of the VXLAN interface to
 	// avoid fragmentation.
 	vxlanEncapuslationOverhead = 50
+
+	// smuggleRoutingTableID is the custom routing table ID managed by smuggle
+	// for policy-based routing. Traffic originating from local container
+	// subnets uses this table to force return paths back through the VXLAN
+	// tunnel.
+	smuggleRoutingTableID = 100
+
+	// smuggleRulePriority is the ip-rule priority for smuggle policy rules.
+	// Lower numbers take precedence; 100 places these rules above the main
+	// table (253) but below local (0) and any operator-defined rules above 100.
+	smuggleRulePriority = 100
 )
 
 type Provider struct {
@@ -58,7 +69,7 @@ func (p *Provider) SetLocal(
 		}
 	}
 
-	vxlanLink, err := p.createIPv4(req.Client, &cfg, req.HostInteface.Index)
+	vxlanLink, err := p.createIPv4(req.Client, &cfg, req.HostInteface.Index, req.HostInteface.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -182,6 +193,75 @@ func (p *Provider) DeleteRemote(
 		return nil, err
 	}
 
+	// Remove the neighbor entry for the remote host's physical IP on the VXLAN
+	// interface that was added for policy routing.
+	hostARPEntry := netlink.Neigh{
+		LinkIndex: vxlan.Index,
+		Family:    syscall.AF_INET,
+		State:     netlink.NUD_PERMANENT,
+		IP:        *req.Subnet.HostIPv4,
+	}
+	if err := retry.Retry(func() error {
+		if err := netlink.NeighDel(&hostARPEntry); err != nil {
+			p.logger.Warn("failed to delete host ARP entry", zap.Error(err))
+			return err
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// Remove the host route from the smuggle routing table.
+	hostRoute := &netlink.Route{
+		LinkIndex: vxlan.Index,
+		Dst: &net.IPNet{
+			IP:   *req.Subnet.HostIPv4,
+			Mask: net.CIDRMask(32, 32),
+		},
+		Table: smuggleRoutingTableID,
+	}
+	if err := retry.Retry(func() error {
+		if err := netlink.RouteDel(hostRoute); err != nil {
+			p.logger.Warn("failed to delete policy host route", zap.Error(err))
+			return err
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// Only remove the ip rules when no host routes remain in the smuggle
+	// routing table. The rules (src localSubnet → table 100) are shared by
+	// all remote hosts; removing them while any remote still has a /32 host
+	// route in table 100 would break policy routing for those remotes.
+	remainingRoutes, err := netlink.RouteListFiltered(syscall.AF_INET, &netlink.Route{
+		Table: smuggleRoutingTableID,
+	}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list routes in smuggle routing table: %w", err)
+	}
+
+	if len(remainingRoutes) == 0 {
+		for _, localSubnet := range req.LocalSubnets {
+			if localSubnet.IPv4Network == nil {
+				continue
+			}
+			rule := netlink.NewRule()
+			rule.Src = localSubnet.IPv4Network.ToIPNet()
+			rule.Table = smuggleRoutingTableID
+			rule.Priority = smuggleRulePriority
+
+			if err := netlink.RuleDel(rule); err != nil && !errors.Is(err, syscall.ENOENT) {
+				return nil, fmt.Errorf("failed to delete policy rule for subnet %s: %w",
+					localSubnet.IPv4Network, err)
+			}
+			p.logger.Debug("removed policy routing rule",
+				zap.String("src_subnet", localSubnet.IPv4Network.String()),
+				zap.Int("table", smuggleRoutingTableID),
+			)
+		}
+	}
+
 	return &types.NetworkProviderDeleteRemoteResp{}, nil
 }
 
@@ -288,6 +368,71 @@ func (p *Provider) SetRemote(
 		return err
 	}); err != nil {
 		return nil, err
+	}
+
+	// Add a neighbor entry mapping the remote host's physical IP to the VTEP
+	// MAC on the VXLAN interface. This allows the host-route below to resolve
+	// L2 without broadcasting on the overlay.
+	hostARPEntry := netlink.Neigh{
+		LinkIndex:    vxlan.Index,
+		Family:       syscall.AF_INET,
+		State:        netlink.NUD_PERMANENT,
+		IP:           *req.Subnet.HostIPv4,
+		HardwareAddr: hwAddr,
+	}
+	if err := retry.Retry(func() error {
+		if err := netlink.NeighSet(&hostARPEntry); err != nil {
+			p.logger.Warn("failed to add host ARP entry", zap.Error(err))
+			return err
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// Add a host route for the remote physical IP into the smuggle routing
+	// table, directing it through the VXLAN interface so the outer UDP/VXLAN
+	// packet uses a symmetric path and AWS security groups track it correctly.
+	hostRoute := &netlink.Route{
+		LinkIndex: vxlan.Index,
+		Dst: &net.IPNet{
+			IP:   *req.Subnet.HostIPv4,
+			Mask: net.CIDRMask(32, 32),
+		},
+		Scope: netlink.SCOPE_LINK,
+		Table: smuggleRoutingTableID,
+	}
+	if err := retry.Retry(func() error {
+		if err := netlink.RouteReplace(hostRoute); err != nil {
+			p.logger.Warn("failed to add policy host route", zap.Error(err))
+			return err
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// For each local subnet, install an ip rule that steers traffic originating
+	// from that subnet into the smuggle routing table. This ensures replies
+	// from local containers to a remote host's physical IP are routed via the
+	// VXLAN interface, so the return path is symmetric.
+	for _, localSubnet := range req.LocalSubnets {
+		if localSubnet.IPv4Network == nil {
+			continue
+		}
+		rule := netlink.NewRule()
+		rule.Src = localSubnet.IPv4Network.ToIPNet()
+		rule.Table = smuggleRoutingTableID
+		rule.Priority = smuggleRulePriority
+
+		if err := netlink.RuleAdd(rule); err != nil && !errors.Is(err, syscall.EEXIST) {
+			return nil, fmt.Errorf("failed to add policy rule for subnet %s: %w",
+				localSubnet.IPv4Network, err)
+		}
+		p.logger.Debug("successfully added policy routing rule",
+			zap.String("src_subnet", localSubnet.IPv4Network.String()),
+			zap.Int("table", smuggleRoutingTableID),
+		)
 	}
 
 	return &types.NetworkProviderSetRemoteResp{}, nil

--- a/internal/types/provider.go
+++ b/internal/types/provider.go
@@ -34,7 +34,8 @@ type NetworkProviderSetResp struct {
 
 // NetworkProviderDeleteRemoteReq contains parameters for deleting a remote subnet.
 type NetworkProviderDeleteRemoteReq struct {
-	Subnet *Subnet
+	Subnet       *Subnet
+	LocalSubnets []*Subnet // local subnets on this host, used for tearing down policy routing rules
 }
 
 // NetworkProviderDeleteRemoteResp is returned after deleting a remote subnet.
@@ -42,7 +43,8 @@ type NetworkProviderDeleteRemoteResp struct{}
 
 // NetworkProviderSetRemoteReq contains parameters for setting up a remote subnet.
 type NetworkProviderSetRemoteReq struct {
-	Subnet *Subnet
+	Subnet       *Subnet
+	LocalSubnets []*Subnet // local subnets on this host, used for policy routing rules
 }
 
 // NetworkProviderSetRemoteResp is returned after setting up a remote subnet.


### PR DESCRIPTION
On hosts with multiple interfaces the kernel routes return traffic via the default gateway rather than the VXLAN interface, breaking stateful firewalls and security groups.

Fix this by installing a per-remote /32 host route in a dedicated routing table and a src-subnet ip rule to steer replies back through the VXLAN interface. Rules are shared across peers and only removed once the last peer route is torn down.