### PR TITLE
http: Fix HTTP server silently failing when listener fails.

### DIFF
--- a/internal/helper/defer.go
+++ b/internal/helper/defer.go
@@ -1,0 +1,6 @@
+package helper
+
+// DeferedErrorIgnore executes the provided function and ignores any error it
+// returns. This is useful for deferred cleanup functions where the error is not
+// critical and should not be handled.
+func DeferedErrorIgnore(fn func() error) { _ = fn() }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -69,8 +70,13 @@ func (s *Server) setupRouter() *chi.Mux {
 func (s *Server) Start() error {
 	s.logger.Info("starting HTTP server", zap.String("address", s.server.Addr))
 
+	ln, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return fmt.Errorf("failed to setup HTTP listener: %w", err)
+	}
+
 	go func() {
-		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := s.server.Serve(ln); err != nil && err != http.ErrServerClosed {
 			s.logger.Error("HTTP server error", zap.Error(err))
 		}
 	}()

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -1,0 +1,71 @@
+package http
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/shoenig/test/must"
+	"go.uber.org/zap"
+
+	"github.com/rasorp/smuggle/internal/config"
+	"github.com/rasorp/smuggle/internal/helper"
+)
+
+// newTestServer creates a Server bound to the given address:port, using a
+// no-op zap logger so tests produce no log output.
+func newTestServer(t *testing.T, addr string, port uint) *Server {
+	t.Helper()
+
+	cfg := &config.HTTPConfig{
+		Address:        addr,
+		Port:           port,
+		AccessLogLevel: "info",
+	}
+
+	return New(cfg, zap.NewNop())
+}
+
+// freePort returns an available TCP port on localhost that is released
+// immediately after discovery. There is a small TOCTOU window, but it is
+// acceptable for tests.
+func freePort(t *testing.T) uint {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	must.NoError(t, err)
+
+	port := uint(ln.Addr().(*net.TCPAddr).Port)
+	must.NoError(t, ln.Close())
+
+	return port
+}
+
+func TestServer_Start_bindsSuccessfully(t *testing.T) {
+	port := freePort(t)
+	s := newTestServer(t, "127.0.0.1", port)
+
+	err := s.Start()
+	must.NoError(t, err)
+
+	// Ensure the server is actually listening by opening a TCP connection.
+	conn, dialErr := net.DialTimeout("tcp", s.server.Addr, time.Second)
+	must.NoError(t, dialErr)
+	_ = conn.Close()
+
+	// Clean shutdown.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	must.NoError(t, s.Shutdown(ctx))
+}
+
+func TestServer_Start_portAlreadyInUse(t *testing.T) {
+	// Hold a port so that our Server cannot bind to it.
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	must.NoError(t, err)
+	defer helper.DeferedErrorIgnore(blocker.Close)
+
+	port := uint(blocker.Addr().(*net.TCPAddr).Port)
+	must.Error(t, newTestServer(t, "127.0.0.1", port).Start())
+}


### PR DESCRIPTION
The HTTP server was silently failing if it was unable to setup its listener. This change uses separate listener and serve functions to create the HTTP server, so this error can be correctly caught and passed back to the caller.