### PR TITLE
cni: Guard against path traversal when writing CNI config file.

### DIFF
--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -78,6 +78,14 @@ func (s *CNIStore) Set(cfg *types.CNIConfig) error {
 	}
 	tempFile = nil // Prevent deferred cleanup from trying to close again
 
+	// Guard against path traversal; cfg.Name must be a plain filename with no
+	// directory components. The name is based on the network name which is
+	// validated on read, but we add this extra check here to be safe since
+	// we're using it as a filename.
+	if cfg.Name != filepath.Base(cfg.Name) {
+		return fmt.Errorf("invalid config name %q: path traversal detected", cfg.Name)
+	}
+
 	filename := filepath.Join(s.path, cfg.Name+".conf")
 
 	// Atomically rename the temporary file to the target path

--- a/internal/store/file/file_test.go
+++ b/internal/store/file/file_test.go
@@ -167,6 +167,32 @@ func TestCNIStore_Set(t *testing.T) {
 			},
 		},
 		{
+			name:      "path traversal via dotdot segments",
+			storePath: t.TempDir(),
+			config: &types.CNIConfig{
+				Name: "../../etc/cron.d/evil",
+				MTU:  1450,
+				IPv4: &types.IPv4CNIConfig{
+					Network: "10.0.0.0/16",
+					Subnet:  "10.0.1.1/24",
+				},
+			},
+			expectedErrorContains: "path traversal detected",
+		},
+		{
+			name:      "path traversal via absolute path in name",
+			storePath: t.TempDir(),
+			config: &types.CNIConfig{
+				Name: "/etc/cron.d/evil",
+				MTU:  1450,
+				IPv4: &types.IPv4CNIConfig{
+					Network: "10.0.0.0/16",
+					Subnet:  "10.0.1.1/24",
+				},
+			},
+			expectedErrorContains: "path traversal detected",
+		},
+		{
 			name:      "read-only directory",
 			storePath: filepath.Join(t.TempDir(), "readonly"),
 			config: &types.CNIConfig{


### PR DESCRIPTION
The CNI config file name is based on the input network name and while this is validated when read, the CNI store should check it does not perform path traversal.

The change adds a check when writing the CNI file to ensure path traversal does not happen.