### PR TITLE
network: Update fingerprint so no external call to discover intf.

### DIFF
--- a/internal/network/fingerprint.go
+++ b/internal/network/fingerprint.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"errors"
 	"fmt"
 	"net"
 )
@@ -71,93 +70,4 @@ func fingerprint(interfaceName string) (*networkFingerprint, error) {
 	}
 
 	return extIface, nil
-}
-
-// getDefaultInterface discovers the default network interface by finding
-// the interface used for the default route.
-func getDefaultInterface() (*net.Interface, error) {
-	// Get all network interfaces
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list interfaces: %w", err)
-	}
-
-	// Try to find the default interface by attempting to connect to a public IP
-	// This doesn't actually send data, just determines which interface would be used
-	conn, err := net.Dial("udp", "8.8.8.8:80")
-	if err != nil {
-		// If we can't dial out, fall back to finding the first non-loopback interface
-		return getFirstNonLoopbackInterface(interfaces)
-	}
-	defer func() { _ = conn.Close() }()
-
-	localAddr := conn.LocalAddr().(*net.UDPAddr)
-
-	// Find the interface that has this local address
-	for _, iface := range interfaces {
-		// Skip down interfaces
-		if iface.Flags&net.FlagUp == 0 {
-			continue
-		}
-
-		// Skip loopback
-		if iface.Flags&net.FlagLoopback != 0 {
-			continue
-		}
-
-		addrs, err := iface.Addrs()
-		if err != nil {
-			continue
-		}
-
-		for _, addr := range addrs {
-			ipNet, ok := addr.(*net.IPNet)
-			if !ok {
-				continue
-			}
-
-			if ipNet.IP.Equal(localAddr.IP) {
-				return &iface, nil
-			}
-		}
-	}
-
-	// If we couldn't find the interface by address, fall back
-	return getFirstNonLoopbackInterface(interfaces)
-}
-
-// getFirstNonLoopbackInterface returns the first non-loopback interface that is up
-// and has an assigned IP address.
-func getFirstNonLoopbackInterface(interfaces []net.Interface) (*net.Interface, error) {
-	for _, iface := range interfaces {
-		// Skip down interfaces
-		if iface.Flags&net.FlagUp == 0 {
-			continue
-		}
-
-		// Skip loopback
-		if iface.Flags&net.FlagLoopback != 0 {
-			continue
-		}
-
-		// Check if it has addresses
-		addrs, err := iface.Addrs()
-		if err != nil || len(addrs) == 0 {
-			continue
-		}
-
-		// Check for at least one non-loopback IP
-		for _, addr := range addrs {
-			ipNet, ok := addr.(*net.IPNet)
-			if !ok {
-				continue
-			}
-
-			if !ipNet.IP.IsLoopback() {
-				return &iface, nil
-			}
-		}
-	}
-
-	return nil, errors.New("no suitable network interface found")
 }

--- a/internal/network/fingerprint_default.go
+++ b/internal/network/fingerprint_default.go
@@ -1,0 +1,57 @@
+//go:build !linux
+
+package network
+
+import (
+	"errors"
+	"net"
+)
+
+// getDefaultInterface is a non-Linux stub. On Linux the implementation uses
+// netlink.RouteGet for a kernel routing-table query with no external I/O.
+// Here we fall back to scanning interfaces, which is the best we can do on
+// platforms that don't support netlink. In practice this path is unreachable
+// at runtime because NewManager returns an error on non-Linux systems.
+func getDefaultInterface() (*net.Interface, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	return getFirstNonLoopbackInterface(ifaces)
+}
+
+// getFirstNonLoopbackInterface returns the first non-loopback interface that is up
+// and has an assigned IP address.
+func getFirstNonLoopbackInterface(interfaces []net.Interface) (*net.Interface, error) {
+	for _, iface := range interfaces {
+		// Skip down interfaces
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+
+		// Skip loopback
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+
+		// Check if it has addresses
+		addrs, err := iface.Addrs()
+		if err != nil || len(addrs) == 0 {
+			continue
+		}
+
+		// Check for at least one non-loopback IP
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+
+			if !ipNet.IP.IsLoopback() {
+				return &iface, nil
+			}
+		}
+	}
+
+	return nil, errors.New("no suitable network interface found")
+}

--- a/internal/network/fingerprint_linux.go
+++ b/internal/network/fingerprint_linux.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package network
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+// getDefaultInterface discovers the default network interface by asking the
+// kernel's routing table which interface it would use to reach an arbitrary
+// external destination. This is a pure local netlink query — no packets are
+// sent and no external IP is contacted, so the call succeeds regardless of
+// egress firewall rules.
+func getDefaultInterface() (*net.Interface, error) {
+
+	// Any routable unicast IP works here; the kernel returns the route it would
+	// use without sending any traffic. We pick 1.2.3.4 as a well-known,
+	// documentation-range address that will never match a local route.
+	routes, err := netlink.RouteGet(net.ParseIP("1.2.3.4"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default route: %w", err)
+	}
+	if len(routes) == 0 {
+		return nil, errors.New("no routes found")
+	}
+
+	iface, err := net.InterfaceByIndex(routes[0].LinkIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup interface with index %d: %w",
+			routes[0].LinkIndex, err)
+	}
+
+	return iface, nil
+}

--- a/internal/network/fingerprint_linux_test.go
+++ b/internal/network/fingerprint_linux_test.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package network
+
+import (
+	"net"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestGetDefaultInterface(t *testing.T) {
+	iface, err := getDefaultInterface()
+	must.NoError(t, err)
+	must.NotNil(t, iface)
+
+	// The returned interface must have a non-empty name and be up.
+	must.NotEq(t, "", iface.Name)
+	must.True(t, iface.Flags&net.FlagUp != 0)
+
+	// It must not be the loopback interface.
+	must.True(t, iface.Flags&net.FlagLoopback == 0)
+
+	// It must have at least one non-loopback address.
+	addrs, err := iface.Addrs()
+	must.NoError(t, err)
+	must.True(t, len(addrs) > 0)
+
+	hasRoutable := false
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if !ipNet.IP.IsLoopback() {
+			hasRoutable = true
+			break
+		}
+	}
+	must.True(t, hasRoutable)
+}


### PR DESCRIPTION
The default interface lookup mechanism used an external network call. In certain environments this could be blocked which breaks this workflow.

This change removes the network call and instead uses a method that does not use network IO.