### PR TITLE
config: Ensure the Nomad token is redacted from JSON marshalling.

### DIFF
--- a/internal/config/nomad.go
+++ b/internal/config/nomad.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/json"
+
 	"github.com/hashicorp/nomad/api"
 	"github.com/urfave/cli/v3"
 
@@ -27,6 +29,23 @@ type NomadConfig struct {
 	ClientKey     string `hcl:"client_key,optional" json:"client_key"`
 	TLSServerName string `hcl:"tls_server_name,optional" json:"tls_server_name"`
 	SkipVerify    *bool  `hcl:"skip_verify,optional" json:"skip_verify"`
+}
+
+// MarshalJSON implements json.Marshaler, so that we can ensure the Token
+// parameter is replaced with "[redacted]" whenever it is non-empty. This
+// ensures that credentials are never exposed in diagnostics, structured logs,
+// or crash dumps.
+func (n NomadConfig) MarshalJSON() ([]byte, error) {
+
+	// 'plain' is a method-free alias of NomadConfig. json.Marshal called on a
+	// plain value uses normal struct serialisation without recursing back into
+	// this method.
+	type plain NomadConfig
+	p := plain(n)
+	if p.Token != "" {
+		p.Token = "[redacted]"
+	}
+	return json.Marshal(p)
 }
 
 func DefaultNomadConfig() *NomadConfig {

--- a/internal/config/nomad_test.go
+++ b/internal/config/nomad_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/shoenig/test/must"
@@ -8,6 +9,47 @@ import (
 
 	"github.com/rasorp/smuggle/internal/helper"
 )
+
+func TestNomadConfig_MarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name          string
+		cfg           *NomadConfig
+		jsonToken     string
+		inMemoryToken string
+	}{
+		{
+			name:          "non-empty token is redacted",
+			cfg:           &NomadConfig{Address: "http://localhost:4646", Token: "s3cr3t-t0k3n"},
+			jsonToken:     "[redacted]",
+			inMemoryToken: "s3cr3t-t0k3n",
+		},
+		{
+			name:          "empty token serialises as empty string",
+			cfg:           &NomadConfig{Address: "http://localhost:4646", Token: ""},
+			jsonToken:     "",
+			inMemoryToken: "",
+		},
+		{
+			name:          "default config has no token to redact",
+			cfg:           DefaultNomadConfig(),
+			jsonToken:     "",
+			inMemoryToken: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.cfg)
+			must.NoError(t, err)
+
+			var out NomadConfig
+			must.NoError(t, json.Unmarshal(data, &out))
+
+			must.Eq(t, tc.jsonToken, out.Token)
+			must.Eq(t, tc.inMemoryToken, tc.cfg.Token)
+		})
+	}
+}
 
 func Test_DefaultNomadConfig(t *testing.T) {
 	cfg := DefaultNomadConfig()


### PR DESCRIPTION
If the resolved config is ever marshalled to JSON (diagnostics, error log, crash dump), the token is exposed in plaintext. This change adds a custom marshal function to redact the token if this were to happen.