### PR TITLE
config: Fix ability to merge and override `DisableIPMasq` value.

### DIFF
--- a/internal/config/agent_test.go
+++ b/internal/config/agent_test.go
@@ -107,7 +107,7 @@ func TestAgentConfig_Merge(t *testing.T) {
 				Client: &ClientConfig{
 					Enabled:       helper.PointerOf(true),
 					DataDir:       "/custom/dir",
-					DisableIPMasq: false,
+					DisableIPMasq: helper.PointerOf(false),
 				},
 				HTTP: &HTTPConfig{
 					Enabled:        helper.PointerOf(true),
@@ -301,7 +301,7 @@ func Test_AgentConfigFromCommand(t *testing.T) {
 				Client: &ClientConfig{
 					Enabled:          helper.PointerOf(true),
 					DataDir:          "/opt/smuggle/subnet",
-					DisableIPMasq:    true,
+					DisableIPMasq:    helper.PointerOf(true),
 					NetworkInterface: "eth0",
 				},
 				HTTP: &HTTPConfig{
@@ -631,7 +631,7 @@ store {
 				Client: &ClientConfig{
 					Enabled:          helper.PointerOf(true),
 					DataDir:          "/var/lib/smuggle/client",
-					DisableIPMasq:    false,
+					DisableIPMasq:    helper.PointerOf(false),
 					NetworkInterface: "eth0",
 				},
 				HTTP: &HTTPConfig{
@@ -728,7 +728,7 @@ store {
 				Client: &ClientConfig{
 					Enabled:          helper.PointerOf(true),
 					DataDir:          "/var/lib/smuggle/client",
-					DisableIPMasq:    false,
+					DisableIPMasq:    helper.PointerOf(false),
 					NetworkInterface: "eth0",
 				},
 				HTTP: &HTTPConfig{

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -29,7 +29,7 @@ type ClientConfig struct {
 
 	// DisableIPMasq disables IP masquerading for the client networks which is
 	// used for routing taffic from the container to the internet.
-	DisableIPMasq bool `hcl:"disable_ipmasq,optional" json:"disable_ipmasq"`
+	DisableIPMasq *bool `hcl:"disable_ipmasq,optional" json:"disable_ipmasq"`
 
 	// NetworkInterface specifies the network interface to use for client
 	// networking. If not specified, the default interface will be identified
@@ -41,7 +41,7 @@ func DefaultClientConfig() *ClientConfig {
 	return &ClientConfig{
 		Enabled:          helper.PointerOf(false),
 		DataDir:          "/var/lib/smuggle/client",
-		DisableIPMasq:    false,
+		DisableIPMasq:    helper.PointerOf(false),
 		NetworkInterface: "",
 	}
 }
@@ -64,7 +64,7 @@ func (c *ClientConfig) Merge(other *ClientConfig) *ClientConfig {
 	if other.DataDir != "" {
 		result.DataDir = other.DataDir
 	}
-	if other.DisableIPMasq {
+	if other.DisableIPMasq != nil {
 		result.DisableIPMasq = other.DisableIPMasq
 	}
 	if other.NetworkInterface != "" {
@@ -131,7 +131,7 @@ func ClientConfigFromCommand(c *cli.Command) *ClientConfig {
 		cfg.Enabled = helper.PointerOf(c.Bool(clientEnabledFlag))
 	}
 	if c.IsSet(clientDisableIPMasqFlag) {
-		cfg.DisableIPMasq = c.Bool(clientDisableIPMasqFlag)
+		cfg.DisableIPMasq = helper.PointerOf(c.Bool(clientDisableIPMasqFlag))
 	}
 
 	return cfg

--- a/internal/config/client_test.go
+++ b/internal/config/client_test.go
@@ -16,7 +16,7 @@ func Test_DefaultClientConfig(t *testing.T) {
 	must.NotNil(t, defaults)
 	must.False(t, *defaults.Enabled)
 	must.Eq(t, "/var/lib/smuggle/client", defaults.DataDir)
-	must.False(t, defaults.DisableIPMasq)
+	must.False(t, *defaults.DisableIPMasq)
 	must.Eq(t, "", defaults.NetworkInterface)
 }
 
@@ -69,12 +69,31 @@ func TestClientConfig_Merge(t *testing.T) {
 			expected: &ClientConfig{DataDir: "/custom/dir"},
 		},
 		{
-			name:  "override fields",
-			base:  &ClientConfig{DataDir: "/base/dir", DisableIPMasq: false},
-			other: &ClientConfig{DataDir: "/other/dir", DisableIPMasq: true},
+			name:  "true overrides false",
+			base:  &ClientConfig{DataDir: "/base/dir", DisableIPMasq: helper.PointerOf(false)},
+			other: &ClientConfig{DataDir: "/other/dir", DisableIPMasq: helper.PointerOf(true)},
 			expected: &ClientConfig{
 				DataDir:       "/other/dir",
-				DisableIPMasq: true,
+				DisableIPMasq: helper.PointerOf(true),
+			},
+		},
+		{
+			// This is the case the original bool type made impossible.
+			name:  "false overrides true",
+			base:  &ClientConfig{DataDir: "/base/dir", DisableIPMasq: helper.PointerOf(true)},
+			other: &ClientConfig{DataDir: "/other/dir", DisableIPMasq: helper.PointerOf(false)},
+			expected: &ClientConfig{
+				DataDir:       "/other/dir",
+				DisableIPMasq: helper.PointerOf(false),
+			},
+		},
+		{
+			name:  "nil DisableIPMasq does not override",
+			base:  &ClientConfig{DataDir: "/base/dir", DisableIPMasq: helper.PointerOf(true)},
+			other: &ClientConfig{DataDir: "/other/dir"},
+			expected: &ClientConfig{
+				DataDir:       "/other/dir",
+				DisableIPMasq: helper.PointerOf(true),
 			},
 		},
 	}
@@ -195,7 +214,7 @@ func Test_ClientConfigFromComand(t *testing.T) {
 			expected: &ClientConfig{
 				Enabled:          helper.PointerOf(true),
 				DataDir:          "/custom/dir",
-				DisableIPMasq:    true,
+				DisableIPMasq:    helper.PointerOf(true),
 				NetworkInterface: "eth0",
 			},
 		},


### PR DESCRIPTION
The zero value of `bool` is `false`, so there was no way to distinguish between not set and false. This change moves to using a pointer, so merging can correctly set false ontop of a true value.