### PR TITLE
cli: Add provider flag to network init command.

### DIFF
--- a/internal/cmd/network/init.go
+++ b/internal/cmd/network/init.go
@@ -14,6 +14,7 @@ func initCommand() *cli.Command {
 		Name:     "init",
 		Category: "network",
 		Usage:    "Creates an example network configuration file",
+		Flags:    initFlags(),
 		Action: func(_ context.Context, cmd *cli.Command) error {
 
 			// Check if smuggle-net.json already exists. If it does, return an
@@ -27,10 +28,25 @@ func initCommand() *cli.Command {
 				return fmt.Errorf("%s already exists", networkInitFilename)
 			}
 
+			// Determine which example content to write based on the provider
+			// flag.
+			var content string
+
+			switch cmd.String("provider") {
+			case "vxlan":
+				content = vxlanNetworkInitContent
+			case "wireguard":
+				content = wireguardNetworkInitContent
+			default:
+				return fmt.Errorf("invalid provider: %q. Valid values are \"vxlan\" and \"wireguard\"",
+					cmd.String("provider"),
+				)
+			}
+
 			// Write out the example.
 			if err := os.WriteFile(
 				networkInitFilename,
-				[]byte(strings.TrimSpace(networkInitContent)),
+				[]byte(strings.TrimSpace(content)),
 				0600,
 			); err != nil {
 				return fmt.Errorf("failed to write file: %w", err)
@@ -47,11 +63,11 @@ const (
 	// which contains an example network configuration.
 	networkInitFilename = "smuggle-net.json"
 
-	// networkInitContent is the content of the example network configuration
-	// file created by the init command. This is a basic VXLAN network that can
-	// be modified and written to Nomad via:
+	// vxlanNetworkInitContent is the content of the example vxlan network
+	// configuration file created by the init command. This is a basic vxlan
+	// network that can be modified and written to Nomad via:
 	// nomad var put smuggle/networks/v1/vxlan data="$(cat smuggle-net.json)".
-	networkInitContent = `
+	vxlanNetworkInitContent = `
 {
   "name": "vxlan",
   "ipmasq": true,
@@ -68,4 +84,32 @@ const (
   }
 }
 `
+
+	// wireguardNetworkInitContent is the content of the example wireguard
+	// network configuration file created by the init command. This is a basic
+	// wireguard network that can be modified and written to Nomad via:
+	// nomad var put smuggle/networks/v1/wireguard data="$(cat smuggle-net.json)".
+	wireguardNetworkInitContent = `
+{
+ "name": "wireguard",
+ "ipmasq": true,
+ "ipv4": {
+   "network": "10.10.0.0/16",
+   "size": 24
+ },
+ "provider": {
+   "name": "wireguard"
+ }
+}
+`
 )
+
+func initFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "provider",
+			Usage: "The network provider to use for the example configuration",
+			Value: "vxlan",
+		},
+	}
+}

--- a/internal/cmd/network/init_test.go
+++ b/internal/cmd/network/init_test.go
@@ -1,0 +1,92 @@
+package network
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/shoenig/test/must"
+	"github.com/urfave/cli/v3"
+)
+
+func TestInitCommand(t *testing.T) {
+	testCases := []struct {
+		name           string
+		args           []string
+		setup          func(t *testing.T)
+		expectedErr    string
+		expectedOutput string
+		expectedFile   string
+	}{
+		{
+			name:           "default provider",
+			args:           []string{"init"},
+			expectedOutput: fmt.Sprintf("successfully wrote file %s\n", networkInitFilename),
+			expectedFile:   strings.TrimSpace(vxlanNetworkInitContent),
+		},
+		{
+			name:           "vxlan provider",
+			args:           []string{"init", "--provider", "vxlan"},
+			expectedOutput: fmt.Sprintf("successfully wrote file %s\n", networkInitFilename),
+			expectedFile:   strings.TrimSpace(vxlanNetworkInitContent),
+		},
+		{
+			name:           "wireguard provider",
+			args:           []string{"init", "--provider", "wireguard"},
+			expectedOutput: fmt.Sprintf("successfully wrote file %s\n", networkInitFilename),
+			expectedFile:   strings.TrimSpace(wireguardNetworkInitContent),
+		},
+		{
+			name:        "invalid provider",
+			args:        []string{"init", "--provider", "bgp"},
+			expectedErr: "invalid provider: \"bgp\". Valid values are \"vxlan\" and \"wireguard\"",
+		},
+		{
+			name: "existing file",
+			args: []string{"init"},
+			setup: func(t *testing.T) {
+				must.NoError(t, os.WriteFile(networkInitFilename, []byte("existing"), 0600))
+			},
+			expectedErr: networkInitFilename + " already exists",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+
+			var buf bytes.Buffer
+
+			cmd := initCommand()
+			cmd.Writer = &buf
+
+			err := cmd.Run(context.Background(), tc.args)
+
+			if tc.expectedErr != "" {
+				must.Error(t, err)
+				must.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				must.NoError(t, err)
+				must.Eq(t, tc.expectedOutput, buf.String())
+
+				content, readErr := os.ReadFile(networkInitFilename)
+				must.NoError(t, readErr)
+				must.Eq(t, tc.expectedFile, string(content))
+			}
+		})
+	}
+}
+
+func Test_initFlags(t *testing.T) {
+	flags := initFlags()
+	must.Eq(t, 1, len(flags))
+	must.Eq(t, "provider", flags[0].Names()[0])
+	must.Eq(t, "vxlan", flags[0].(*cli.StringFlag).Value)
+}


### PR DESCRIPTION
Smuggle now supports more than a single network provider, so the init command should allow for generating network configs for all supported providers.

This change adds a provider flag which can be used to generate vxlan and wireguard example network configs. It defaults to vxlan which was the existing behaviour.